### PR TITLE
Enable "moduleResolution": "bundler"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist-es/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
If you use `estree-toolkit` in a project that has the following `tsconfig.json`...

```json
{
  "compilerOptions": {
    "moduleResolution": "bundler"
  }
}
```

...running `tsc` results in the following error:

> error TS7016: Could not find a declaration file for module 'estree-toolkit'. 'path/to/node_modules/estree-toolkit/dist-es/index.mjs' implicitly has an 'any' type.
> There are types at 'path/to/node_modules/estree-toolkit/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'estree-toolkit' library may need to update its package.json or typings.

`"moduleResolution": "bundler"` is the best default for new projects, since it enables TypeScript to get types for subpackages declared via the `"exports"` field of package.json

This PR makes it work. Projects using `"moduleResolution": "node"` (or whatever) will be unaffected.