### PR TITLE
Add default type for generic `CompT`

### DIFF
--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -240,7 +240,7 @@ export class Traverser {
   }
 }
 
-export const traverse = <NodeT, StateT, CompT extends string>(
+export const traverse = <NodeT, StateT, CompT extends string = never>(
   node: NodeT,
   visitors: Visitors<StateT, CompT> & { $?: TraverseOptions },
   state?: StateT


### PR DESCRIPTION
Release v1.7.9 added a new generic parameter to the traverse function. This works fine when generics are inferred (`traverse(node, visitors, state)`), but it breaks when explicit generic parameters are provided (`traverse<MyNode, MyState>(node, visitors, state)`) because the new parameter is missing.

This PR adds a default type to the new generic parameter, so that existing usage of the `traverse` function will still work.