### PR TITLE
Fix: Incorrect Renaming in AssignmentPattern Inside ObjectPattern

### DIFF
--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1632,6 +1632,14 @@ export class Scope {
     ) {
       (parent.value as Identifier).name = newName
       parent.shorthand = (parent.value as Identifier).name === (parent.key as Identifier).name
+    } else if (
+      parent.type === 'AssignmentPattern' &&
+      path.parentPath?.parent?.type === 'Property' &&
+      path.parentPath.parentPath?.parent?.type === 'ObjectPattern'
+    ) {
+      const property = path.parentPath.parent
+      parent.left = b.identifier(newName)
+      property.shorthand = parent.left.name === (property.key as Identifier).name
     } else {
       path.node!.name = newName
     }

--- a/tests/snapshots/scope.test.js.snap
+++ b/tests/snapshots/scope.test.js.snap
@@ -151,9 +151,10 @@ exports[`methods rename Patterns 1`] = `
 "const {a: b} = global;
 rep_a_b;
 ({a: b} = newGlobal);
-const x = ({d: e, y: [g]} = b) => {
+const x = ({d: e, y: [g], h: i = 1} = b) => {
   rep_d_e;
   rep_f_g;
+  rep_h_i;
 };
 "
 `;

--- a/tests/src/scope.test.ts
+++ b/tests/src/scope.test.ts
@@ -981,9 +981,10 @@ describe('methods', () => {
 
         ({a} = newGlobal)
 
-        const x = ({ d, y: [f] } = a) => {
+        const x = ({ d, y: [f], h = 1 } = a) => {
           rep_d_e;
           rep_f_g;
+          rep_h_i;
         }
       `)
 


### PR DESCRIPTION
This PR fixes a bug where renaming an identifier within an AssignmentPattern inside an ObjectPattern was producing incorrect output.

# Before (Buggy Output)

Renaming `a` to `b` in this example:

```ts
const { a = 1 } = {};
```

Should result in:

```ts
const { a: b = 1 } = {};
```

But currently produces:

```ts
const { b = 1 } = {};
```

#  Reproduction Example

```ts
import { generate } from "astring";
import { traverse } from "estree-toolkit";
import { parseModule } from "meriyah";

const ast = parseModule(`
  const { a = 1 } = {};
`);

traverse(ast, {
  $: { scope: true },
  Program(node) {
    node.scope?.renameBinding("a", "b");
  },
});

console.log(generate(ast));
```

# Note

The creation of a new `Identifier` inside the `renameConsideringParent` method was necessary because the `left` property of the `AssignmentPattern` is the same reference as the `key` in the `Property`.